### PR TITLE
Added flag for free models and .env support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.gradio/certificate.pem
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ datasets==2.18.0
 librosa==0.10.1
 soundfile==0.12.1
 openai==1.52.0
+python-dotenv==1.0.1
+httpx==0.27.2


### PR DESCRIPTION
Now if you run

`python src/talk_arena/demo.py --free_only`

It will start the arena and only use free models.  This is useful for debugging when you don't want to pay for model calls.

I also added .env file support.  Add .env file at the base of the repository.